### PR TITLE
chore: release 3.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ironarachne/words",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ironarachne/words",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "devDependencies": {
         "@biomejs/biome": "^2.3.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ironarachne/words",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A library for dealing with words",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## What changed

Version bump to 3.0.1. Nothing else — this commit touches only
`package.json` and `package-lock.json`.

`src/` is unchanged since 3.0.0, so this release ships no behavior change.
It exercises the new tag-driven release pipeline (#3) end to end: OIDC
trusted publishing to npm with provenance, and an auto-generated GitHub
Release. Everything since 3.0.0 is tooling and documentation.

## Related issue

None.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (changes existing behavior or the public API)
- [x] Documentation or tooling only

## Language behavior

- [x] This change does **not** alter the output of an existing function for
      input it already handled.

## Checklist

- [x] `npm run check` passes locally (lint, build, tests).
- [ ] Tests cover the new behavior, including boundaries and thrown errors.
- [ ] TSDoc comments are updated for any changed public API.
- [ ] `README.md` is updated if the public API changed.
- [x] The change follows [CODE_STYLE.md](../CODE_STYLE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)